### PR TITLE
Add new parameter to indicate if image must be pulled

### DIFF
--- a/src/main/java/com/github/geowarin/junit/DockerRule.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRule.java
@@ -51,7 +51,9 @@ public class DockerRule extends ExternalResource {
     ContainerConfig containerConfig = createContainerConfig(params.imageName, params.ports, params.cmd);
 
     try {
-      dockerClient.pull(params.imageName);
+      if (!params.isLocalImage) {
+        dockerClient.pull(params.imageName);
+      }
       container = dockerClient.createContainer(containerConfig);
     } catch (DockerException | InterruptedException e) {
       throw new IllegalStateException(e);

--- a/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
@@ -41,6 +41,15 @@ public class DockerRuleBuilder {
     return this;
   }
 
+ /**
+  * @param isLocalImage If the image has been built locally
+  * @return The builder
+  */
+  public DockerRuleBuilder isLocalImage(boolean isLocalImage) {
+    params.isLocalImage = isLocalImage;
+    return this;
+  }
+
   /**
    * Utility method to ensure a container is started
    *

--- a/src/main/java/com/github/geowarin/junit/DockerRuleParams.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRuleParams.java
@@ -10,4 +10,6 @@ public class DockerRuleParams {
   String portToWaitOn;
   public int waitTimeout;
   String logToWait;
+
+  boolean isLocalImage;
 }


### PR DESCRIPTION
Hi,

I just discovered this project and I must say it is really cool; thanks a lot!

I found out that the current implementation assumes the image is always remote. However, sometimes images are built and kept locally.

I added a new param to indicate if the image must be pulled or not: 

```
if (!params.isLocalImage) {
  dockerClient.pull(params.imageName);
}
```

We can use it like this:

```
DockerRule.builder()
      .image("myImages/rabbitmq:management")
      .ports("5672")
      .isLocalImage(true)
      .waitForLog("Server startup complete")
      .build();
```
