### PR TITLE
Wait before proceed parameter

### DIFF
--- a/src/main/java/com/github/geowarin/junit/DockerRule.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRule.java
@@ -1,7 +1,19 @@
 package com.github.geowarin.junit;
 
-import com.spotify.docker.client.*;
-import com.spotify.docker.client.messages.*;
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerCertificateException;
+import com.spotify.docker.client.DockerCertificates;
+import com.spotify.docker.client.DockerClient;
+import static com.spotify.docker.client.DockerClient.LogsParam.follow;
+import static com.spotify.docker.client.DockerClient.LogsParam.stdout;
+import com.spotify.docker.client.DockerException;
+import com.spotify.docker.client.LogMessage;
+import com.spotify.docker.client.LogStream;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerCreation;
+import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.PortBinding;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.rules.ExternalResource;
@@ -18,8 +30,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.spotify.docker.client.DockerClient.LogsParam.*;
 
 /**
  * <p>
@@ -64,6 +74,10 @@ public class DockerRule extends ExternalResource {
     dockerClient.startContainer(container.id());
     ContainerInfo info = dockerClient.inspectContainer(container.id());
     ports = info.networkSettings().ports();
+
+    if(params.waitBeforeProceed != null) {
+      Thread.sleep(params.waitBeforeProceed);
+    }
 
     if (params.portToWaitOn != null) {
       waitForPort(getHostPort(params.portToWaitOn), params.waitTimeout);

--- a/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
@@ -52,6 +52,17 @@ public class DockerRuleBuilder {
   }
 
   /**
+   * Utility method to wait before proceed with further checks
+   *
+   * @param waitBeforeProceed waiting time in milliseconds
+   * @return The builder
+   */
+  public DockerRuleBuilder waitBeforeProceed(Integer waitBeforeProceed) {
+    params.waitBeforeProceed  = waitBeforeProceed;
+    return this;
+  }
+
+  /**
    * Utility method to ensure a container is started
    *
    * @param portToWaitOn    The port to wait on

--- a/src/main/java/com/github/geowarin/junit/DockerRuleParams.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRuleParams.java
@@ -10,4 +10,6 @@ public class DockerRuleParams {
   String portToWaitOn;
   public int waitTimeout;
   String logToWait;
+
+  Integer waitBeforeProceed;
 }


### PR DESCRIPTION
I realized today that some containers need a separate wait step before the checks for port or log line could be executed.

For example the official postgres container restarts postgres once, to enable some settings.

This change introduces the parameter _waitBeforeProceed_ which, if set, waits the specified time before the other checks are executed.
