### PR TITLE
Add new fields to DockerRuleParams

### DIFF
--- a/src/main/java/com/github/geowarin/junit/DockerRule.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRule.java
@@ -136,7 +136,7 @@ public class DockerRule extends ExternalResource {
       final DefaultDockerClient.Builder builder = new DefaultDockerClient.Builder();
       final String UNIX_SCHEME = "unix";
       String endpoint = params.dockerHost;
-      final Path dockerCertPath = Paths.get(params.dockerHost);
+      final Path dockerCertPath = Paths.get(params.dockerCertPath);
       Optional<DockerCertificates> certs = Optional.absent();
       try {
         certs = DockerCertificates.builder()

--- a/src/main/java/com/github/geowarin/junit/DockerRule.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRule.java
@@ -157,6 +157,10 @@ public class DockerRule extends ExternalResource {
         final String address = isNullOrEmpty(hostText) ? DEFAULT_HOST : hostText;
 
         builder.uri(scheme + "://" + address + ":" + port);
+
+        if (certs.isPresent()) {
+          builder.dockerCertificates(certs.get());
+        }
       }
       return builder.build();
     }

--- a/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
@@ -74,6 +74,16 @@ public class DockerRuleBuilder {
     return this;
   }
 
+  public DockerRuleBuilder dockerHost(String dockerHost) {
+    params.dockerHost = dockerHost;
+    return this;
+  }
+
+  public DockerRuleBuilder dockerCertPath(String dockerCertPath) {
+    params.dockerCertPath = dockerCertPath;
+    return this;
+  }
+
   public DockerRule build() {
     return new DockerRule(params);
   }

--- a/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRuleBuilder.java
@@ -1,5 +1,7 @@
 package com.github.geowarin.junit;
 
+import com.spotify.docker.client.messages.ContainerConfig;
+
 public class DockerRuleBuilder {
   private final DockerRuleParams params = new DockerRuleParams();
 
@@ -71,6 +73,11 @@ public class DockerRuleBuilder {
    */
   public DockerRuleBuilder waitForLog(String logToWait) {
     params.logToWait = logToWait;
+    return this;
+  }
+
+  public DockerRuleBuilder config(ContainerConfig config) {
+    params.config = config;
     return this;
   }
 

--- a/src/main/java/com/github/geowarin/junit/DockerRuleParams.java
+++ b/src/main/java/com/github/geowarin/junit/DockerRuleParams.java
@@ -1,5 +1,7 @@
 package com.github.geowarin.junit;
 
+import com.spotify.docker.client.messages.ContainerConfig;
+
 public class DockerRuleParams {
 
   String imageName;
@@ -10,4 +12,9 @@ public class DockerRuleParams {
   String portToWaitOn;
   public int waitTimeout;
   String logToWait;
+
+  ContainerConfig config;
+  String dockerHost;
+  String dockerCertPath;
+
 }


### PR DESCRIPTION
When I was writing local tests with the use of your  dockerRule and  docker toolbox I faced with the following problems:
I needed to set DOCKER_HOST and DOCKER_CERT_PATH in env settings, therefore I added   DockerRuleBuilder, dockerHost and dockerCertPath.
Also when I created docker container I needed to set env property for it. That’s why I added  ContainerConfig to the DockerRuleBuilder so that it would be possible to pass any settings to container.
Following that I want to add some code to your project so that such problems were resolved
