### PR TITLE
Upgrade com.spotify:docker-client:8.9.1 -> 8.14.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
   compile 'org.slf4j:slf4j-api:1.7.12'
-  compile 'com.spotify:docker-client:8.9.1'
+  compile 'com.spotify:docker-client:8.14.1'
   compileOnly('junit:junit:4.12')
   testCompile('junit:junit:4.12')
   testCompile 'org.slf4j:slf4j-simple:1.7.12'


### PR DESCRIPTION
This upgrades the docker-client to the latest release.

I ran into https://github.com/spotify/docker-client/issues/1016 after pulling in the docker-junit-rule dependency from a classpath conflict. Updating the docker-client to the latest resolved the problem. If you're open to it, it'd be great to have the rule itself pull in a more recent version of the client.